### PR TITLE
Move the parsing of Protocols() into a dedicated function

### DIFF
--- a/main.go
+++ b/main.go
@@ -130,28 +130,7 @@ func (d *Daemon) Protocols() ([]Protocol, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	var protocols []Protocol
-	for _, line := range strings.Split(strings.TrimSuffix(protocolsString, "\n"), "\n") {
-		line = trimDupSpace(line)
-		// Skip header
-		if !(strings.Contains(line, "Name Proto Table") || strings.Contains(line, "ready.")) {
-			parts := strings.Split(line, " ")
-			timeVal, err := time.Parse("2006-01-02 15:04:05", parts[4]+" "+parts[5])
-			if err != nil {
-				return nil, err
-			}
-			protocols = append(protocols, Protocol{
-				Name:  parts[0],
-				Proto: parts[1],
-				Table: parts[2],
-				State: parts[3],
-				Since: timeVal,
-				Info:  strings.Join(parts[6:], " "),
-			})
-		}
-	}
-	return protocols, nil
+	return ParseShowProtocols(protocolsString)
 }
 
 // Routes gets a slice of parsed routes

--- a/protocol.go
+++ b/protocol.go
@@ -211,6 +211,9 @@ func ParseShowProtocols(protocolsString string) ([]Protocol, error) {
 		// Skip header
 		if !(strings.Contains(line, "Name Proto Table") || strings.Contains(line, "ready.")) {
 			parts := strings.Split(line, " ")
+			if len(parts) < 6 {
+				continue
+			}
 			info := strings.Join(parts[6:], " ")
 			establishedSince := parts[4] + " " + parts[5]
 			layout := "2006-01-02 15:04:05"

--- a/protocol.go
+++ b/protocol.go
@@ -203,6 +203,7 @@ func Parse(p string) ([]*ProtocolState, error) {
 }
 
 // ParseShowProtocols parses the output of `show protocols`
+// bird must be configured to use the iso long timeformat. Other timeformats are currently not supported
 func ParseShowProtocols(protocolsString string) ([]Protocol, error) {
 	var protocols []Protocol
 	for _, line := range strings.Split(strings.TrimSuffix(protocolsString, "\n"), "\n") {
@@ -210,14 +211,9 @@ func ParseShowProtocols(protocolsString string) ([]Protocol, error) {
 		// Skip header
 		if !(strings.Contains(line, "Name Proto Table") || strings.Contains(line, "ready.")) {
 			parts := strings.Split(line, " ")
-			layout := "2006-01-02"
-			establishedSince := parts[4]
-			info := strings.Join(parts[5:], " ")
-			if len(parts) > 6 {
-				layout = "2006-01-02 15:04:05"
-				establishedSince = parts[4] + " " + parts[5]
-				info = strings.Join(parts[6:], " ")
-			}
+			info := strings.Join(parts[6:], " ")
+			establishedSince := parts[4] + " " + parts[5]
+			layout := "2006-01-02 15:04:05"
 			timeVal, err := time.Parse(layout, establishedSince)
 			if err != nil {
 				return nil, err

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -384,15 +384,10 @@ func TestProtocolParseRoutes(t *testing.T) {
 }
 
 const testInputShowProtocolsLongRunning = `Name       Proto      Table      State  Since         Info
-session1 BGP        ---        up     2024-07-22    Established   
-session2 BGP        ---        start     2024-07-22    Passive   
-direct1    Direct     ---        up     2024-06-17    
-kernel1    Kernel     master4    up     2024-06-17 `
-
-const testInputShowProtocolsShortRunning = `Name       Proto      Table      State  Since         Info
-session1 BGP        ---        up     14:07:29.523    Established   
-session2 BGP        ---        up     12:18:11.199    Established
-`
+session1 BGP        ---        up     2024-07-22 00:00:12   Established   
+session2 BGP        ---        start     2024-07-22 00:00:13   Passive   
+direct1    Direct     ---        up     2024-06-17 00:00:14   
+kernel1    Kernel     master4    up     2024-06-17 15:03:12`
 
 func mustParseTime(layout, s string) time.Time {
 	t, err := time.Parse(layout, s)
@@ -403,6 +398,7 @@ func mustParseTime(layout, s string) time.Time {
 }
 
 func TestParseShowProtocols(t *testing.T) {
+	const layout = "2006-01-02 15:04:05"
 	for _, tc := range []struct {
 		In        string
 		Protocols []Protocol
@@ -415,7 +411,7 @@ func TestParseShowProtocols(t *testing.T) {
 					Proto: "BGP",
 					Table: "---",
 					State: "up",
-					Since: mustParseTime("2006-01-02", "2024-07-22"),
+					Since: mustParseTime(layout, "2024-07-22 00:00:12"),
 					Info:  "Established",
 				},
 				{
@@ -423,7 +419,7 @@ func TestParseShowProtocols(t *testing.T) {
 					Proto: "BGP",
 					Table: "---",
 					State: "start",
-					Since: mustParseTime("2006-01-02", "2024-07-22"),
+					Since: mustParseTime(layout, "2024-07-22 00:00:13"),
 					Info:  "Passive",
 				},
 				{
@@ -431,35 +427,14 @@ func TestParseShowProtocols(t *testing.T) {
 					Proto: "Direct",
 					Table: "---",
 					State: "up",
-					Since: mustParseTime("2006-01-02", "2024-06-17"),
+					Since: mustParseTime(layout, "2024-06-17 00:00:14"),
 				},
 				{
 					Name:  "kernel1",
 					Proto: "Kernel",
 					Table: "master4",
 					State: "up",
-					Since: mustParseTime("2006-01-02", "2024-06-17"),
-				},
-			},
-		},
-		{
-			In: testInputShowProtocolsShortRunning,
-			Protocols: []Protocol{
-				{
-					Name:  "session1",
-					Proto: "BGP",
-					Table: "---",
-					State: "up",
-					Since: mustParseTime("2006-01-02", "2024-07-22"),
-					Info:  "Established",
-				},
-				{
-					Name:  "session2",
-					Proto: "BGP",
-					Table: "---",
-					State: "up",
-					Since: mustParseTime("2006-01-02", "2024-07-22"),
-					Info:  "Established",
+					Since: mustParseTime(layout, "2024-06-17 15:03:12"),
 				},
 			},
 		},

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -404,6 +404,9 @@ func TestParseShowProtocols(t *testing.T) {
 		Protocols []Protocol
 	}{
 		{
+			In: "invalid input",
+		},
+		{
 			In: testInputShowProtocolsLongRunning,
 			Protocols: []Protocol{
 				{


### PR DESCRIPTION
This allows developers to use the parsing functionality without the socket functionality. 